### PR TITLE
Fix deployment by adding health check server

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,7 @@
 import asyncio
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import os
+import threading
 from telegram import Bot
 from config import TOKEN, CHAT_ID, SYMBOLS
 from market_data import recuperer_donnees
@@ -54,5 +57,18 @@ async def main():
         await verifier_et_envoyer_signal(bot)
         await asyncio.sleep(300)  # 5 minutes
 
+class HealthHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"OK")
+
+def run_health_server():
+    port = int(os.getenv("PORT", 8080))
+    server = HTTPServer(("", port), HealthHandler)
+    server.serve_forever()
+
 if __name__ == "__main__":
+    server_thread = threading.Thread(target=run_health_server, daemon=True)
+    server_thread.start()
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- keep service alive by launching a simple HTTP server on startup

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_683fe2b48b548323a9a8fc0de6cdc15d